### PR TITLE
[SELC-2735] HeroSlider & CtaBanner additional fields

### DIFF
--- a/src/app/src/components/block-context/content-items.json
+++ b/src/app/src/components/block-context/content-items.json
@@ -25,9 +25,14 @@
       "type": "media",
       "multiple": false,
       "required": false,
-      "allowedTypes": ["images"]
+      "allowedTypes": [
+        "images"
+      ]
     },
     "linkLabel": {
+      "type": "string"
+    },
+    "youtubeVideo": {
       "type": "string"
     }
   }

--- a/src/app/src/components/shared/block-cta-banner.json
+++ b/src/app/src/components/shared/block-cta-banner.json
@@ -15,6 +15,14 @@
     },
     "linkLabel": {
       "type": "string"
+    },
+    "theme": {
+      "type": "enumeration",
+      "enum": [
+        "light",
+        "dark"
+      ],
+      "default": "dark"
     }
   }
 }

--- a/src/app/src/components/shared/block-hero-slider.json
+++ b/src/app/src/components/shared/block-hero-slider.json
@@ -10,6 +10,10 @@
       "type": "component",
       "repeatable": true,
       "component": "block-context.content-items"
+    },
+    "slug": {
+      "type": "string",
+      "unique": true
     }
   }
 }


### PR DESCRIPTION
## Description
- Adds youtubeVideo and slug to hero-slider
- Adds theme enum to cta-banner

Fixes # [SELC-2735](https://pagopa.atlassian.net/browse/SELC-2735)

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Visual testing


[SELC-2735]: https://pagopa.atlassian.net/browse/SELC-2735?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ